### PR TITLE
fix: request refresh after arming

### DIFF
--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -85,14 +85,17 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         await self.hass.async_add_executor_job(self._hkc_alarm.disarm)
+        await self.coordinator.async_request_refresh()
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
         await self.hass.async_add_executor_job(self._hkc_alarm.arm_partset_a)
+        await self.coordinator.async_request_refresh()
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
         await self.hass.async_add_executor_job(self._hkc_alarm.arm_fullset)
+        await self.coordinator.async_request_refresh()
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
This update adds a request refresh after arming/disarming. This ensures the state updates when arming/disarming - fixing the 'sorry there was an error' with the google assistant HA Cloud integration.