### PR TITLE
fix(29): Add input states for tamper & inhibited

### DIFF
--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -141,6 +141,16 @@ class HKCSensor(CoordinatorEntity):
                 f"Sensor {self.name} state determined as 'Open' due to inputState being 1."
             )
             return "Open"
+        elif self._input_data["inputState"] == 2:
+            _logger.debug(
+                f"Sensor {self.name} state determined as 'Tamper' due to inputState being 2."
+            )
+            return "Tamper"
+        elif self._input_data["inputState"] == 5:
+            _logger.debug(
+                f"Sensor {self.name} state determined as 'Inhibited' due to inputState being 5."
+            )
+            return "Inhibited"
         else:
             _logger.debug(f"Sensor {self.name} state determined as 'Closed'.")
             return "Closed"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,6 +14,14 @@ mock_sensor_data = {
     "inputState": 1,
 }
 
+# Mock tampered sensor data for HKCSensor to process
+mock_tampered_sensor_data = {
+    "inputId": "2",
+    "description": "Front Door",
+    "timestamp": "2024-09-02T12:00:00Z",
+    "inputState": 2,
+}
+
 
 class MockCoordinator:
     async_request_refresh = AsyncMock()
@@ -39,6 +47,22 @@ async def test_hkc_sensor_state(hass, aioclient_mock):
         assert (
             sensor.state == "Open"
         )  # as per your logic, inputState being 1 should result in state "Open"
+
+@pytest.mark.asyncio
+async def test_hkc_sensor_tampered_state(hass, aioclient_mock):
+    with patch.object(HKCSensor, "_panel_data", {"display": "Thu 26 Oct 10:35"}):
+        mock_coordinator = MockCoordinator()
+        sensor = HKCSensor(
+            "hkc_alarm_instance", mock_tampered_sensor_data, mock_coordinator
+        )
+        await sensor.async_update()
+
+        print(f"Mock Sensor Data: {mock_sensor_data}")
+        print(f"Sensor State: {sensor.state}")
+
+        assert (
+            sensor.state == "Tamper"
+        ) # as per your logic, inputState being 2 should result in state "Tamper"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#29 

Adds input states for when sensor is in tamper or inhibited.

Use case: currently extending house, so seeing these states when removing windows / knocking walls.

![image](https://github.com/user-attachments/assets/81159789-db17-4b65-98fe-b73fedab39f3)

![image](https://github.com/user-attachments/assets/61069d7d-76c7-4dff-bab0-6a65ac585c53)

