### PR TITLE
Remove custom service for testing

### DIFF
--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -230,18 +230,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     await coordinator.async_config_entry_first_refresh()
 
-    # Register a custom service for testing
-    async def async_force_refresh(service_call):
-        """Force refresh data from HKC."""
-        await coordinator.async_request_refresh()
-
-    hass.services.async_register(
-        DOMAIN,
-        "force_refresh",
-        async_force_refresh,
-        schema=vol.Schema({}),
-    )
-
     all_inputs = coordinator.data
     # Filter out the inputs with empty description
     filtered_inputs = [

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -6,8 +6,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .const import DOMAIN
 from datetime import datetime, timedelta
-from homeassistant.helpers.service import async_register_admin_service
-import voluptuous as vol
 from homeassistant.helpers.event import async_track_time_interval
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
 from homeassistant.helpers.update_coordinator import CoordinatorEntity


### PR DESCRIPTION
Removes the custom service. It's not needed, as invoking action `homeassistant.update_entity` on classes with the `CoordinatorEntity` mixin will call its `async_update` method which refreshes the associated DataUpdateCoordinator.

It also prevents the following error from being logged on integration startup (at least on 2025.4.1), which is generated by [homeassistant/helpers/service.py](https://github.com/home-assistant/core/blob/8840970d647846fa72538f13977905e29a5e2da6/homeassistant/helpers/service.py#L744):
```
2025-05-13 14:46:09.568 ERROR (MainThread) [homeassistant.helpers.service] Failed to load integration: hkc_alarm
NoneType: None
```

The integration loads, but the error might be due to a missing definition for the service in `services.yaml`