### PR TITLE
Add options flow to integration

### DIFF
--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -23,11 +23,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     @callback
-    def update_options(updated_entry: ConfigEntry) -> None:
-        update_interval = updated_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-        hass.data[DOMAIN][updated_entry.entry_id]["scan_interval"] = timedelta(seconds=update_interval)
+    async def update_options(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        hass.data[DOMAIN][config_entry.entry_id]["scan_interval"] = timedelta(seconds=update_interval)
 
-    entry.add_update_listener(update_options)
+    entry.async_on_unload(entry.add_update_listener(update_options))
 
     await hass.config_entries.async_forward_entry_setups(
         entry, ["alarm_control_panel", "sensor"]

--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -118,7 +118,7 @@ class HKCAlarmControlPanel(AlarmControlPanelEntity, CoordinatorEntity):
 
 async def async_setup_entry(hass, entry, async_add_entities):
     hkc_alarm = hass.data[DOMAIN][entry.entry_id]
-    update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
 
     async def _async_fetch_data():
         try:

--- a/custom_components/hkc_alarm/config_flow.py
+++ b/custom_components/hkc_alarm/config_flow.py
@@ -1,13 +1,10 @@
 """Config flow for HKC Alarm."""
 import logging
-from pyhkc.hkc_api import HKCAlarm
-from homeassistant import config_entries, exceptions
-from homeassistant.core import callback
 import voluptuous as vol
-
+from pyhkc.hkc_api import HKCAlarm
+from homeassistant import config_entries
+from homeassistant.core import callback
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
-
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -204,7 +204,7 @@ class HKCSensor(CoordinatorEntity):
 
 async def async_setup_entry(hass, entry, async_add_entities):
     hkc_alarm = hass.data[DOMAIN][entry.entry_id]
-    update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
 
     async def _async_fetch_data():
         try:

--- a/custom_components/hkc_alarm/translations/en.json
+++ b/custom_components/hkc_alarm/translations/en.json
@@ -9,12 +9,6 @@
           "panel_id": "Panel ID",
           "update_interval": "Update Interval (seconds)"
         }
-      },
-      "options": {
-        "title": "Options",
-        "data": {
-          "update_interval": "Update Interval (seconds)"
-        }
       }
     },
     "error": {
@@ -24,6 +18,16 @@
     },
     "abort": {
       "already_configured": "HKC Alarm integration is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "data": {
+          "update_interval": "Update Interval (seconds)"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Enable reconfiguration of the update interval via options flow.

**Breaking change**: `CONF_UPDATE_INTERVAL` is moved from `config_entry.data` to `config_entry.options`.

* Still needs config entry migration to new config entry version, so that `CONF_UPDATE_INTERVAL` can be moved
* Actually changing the update interval is dependent on separate PR to create `DataUpdateCoordinator`s in `__init__.py`.