### PR TITLE
Use shared coordinators for alarm polling

### DIFF
--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -1,9 +1,47 @@
+import logging
 from pyhkc.hkc_api import HKCAlarm
-from datetime import timedelta
-from homeassistant.core import HomeAssistant
+from datetime import datetime, timezone, timedelta
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import Throttle
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
+
+_logger = logging.getLogger(__name__)
+
+class HKCAlarmCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, hkc_alarm: HKCAlarm, update_interval) -> None:
+        super().__init__(
+            hass,
+            _logger,
+            config_entry=config_entry,
+            name="hkc_alarm_data",
+            update_interval=timedelta(seconds=update_interval),
+        )
+        self._last_update = datetime.min
+        self._hkc_alarm = hkc_alarm
+        self.panel_time_offset = None
+        self.status = None
+        self.panel_data = None
+        # self.sensor_data = None
+
+    async def _async_update_data(self):
+        @Throttle(timedelta(seconds=30))
+        def fetch_data():
+            self.status = self._hkc_alarm.get_system_status()
+            self.panel_data = self._hkc_alarm.get_panel()
+            # self.sensor_data = self.hkc_alarm.get_all_inputs()
+
+        try:
+            now = datetime.now(timezone.utc)
+            if now > self._last_update + timedelta(seconds=30):
+                self._last_update = now
+                await self.hass.async_add_executor_job(fetch_data)
+            return self.status, self.panel_data #, self.sensor_data
+        except Exception as e:
+            _logger.error(f"Exception occurred while fetching HKC data: {e}")
+            raise UpdateFailed(f"Failed to update: {e}")
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     panel_id = entry.data["panel_id"]
@@ -15,17 +53,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-    scan_interval = timedelta(seconds=update_interval)
+    alarm_coordinator = HKCAlarmCoordinator(hass, entry, hkc_alarm, update_interval)
+    await alarm_coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "hkc_alarm": hkc_alarm,
-        "scan_interval": scan_interval,
+        "update_interval": update_interval,
+        "alarm_coordinator": alarm_coordinator,
     }
 
     @callback
     def update_options(updated_entry: ConfigEntry) -> None:
         update_interval = updated_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-        hass.data[DOMAIN][updated_entry.entry_id]["scan_interval"] = timedelta(seconds=update_interval)
+        hass.data[DOMAIN][updated_entry.entry_id]["update_interval"] = update_interval
+        ## TODO: update active coordinator intervals
 
     entry.add_update_listener(update_options)
 

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
+from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class HKCAlarmCoordinator(DataUpdateCoordinator):
 
         try:
             now = datetime.now(timezone.utc)
-            if self._last_update is None or now > self._last_update + timedelta(seconds=30):
+            if self._last_update is None or now > self._last_update + timedelta(seconds=MIN_UPDATE_INTERVAL):
                 self._last_update = now
                 await self.hass.async_add_executor_job(fetch_data)
             return self.status, self.panel_data #, self.sensor_data
@@ -63,7 +63,7 @@ class HKCSensorCoordinator(DataUpdateCoordinator):
         try:
             await self._alarm_coordinator.async_refresh()
             now = datetime.now(timezone.utc)
-            if self._last_update is None or now > self._last_update + timedelta(seconds=30):
+            if self._last_update is None or now > self._last_update + timedelta(seconds=MIN_UPDATE_INTERVAL):
                 self._last_update = now
                 await self.hass.async_add_executor_job(fetch_data)
             return self.sensor_data

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -68,7 +68,7 @@ class HKCSensorCoordinator(DataUpdateCoordinator):
                 await self.hass.async_add_executor_job(fetch_data)
             return self.sensor_data
         except Exception as e:
-            _logger.error(f"Exception occurred while fetching HKC data: {e}")
+            _logger.error(f"Exception occurred while fetching HKC sensor data: {e}")
             _logger.error(traceback.format_exc())
             raise UpdateFailed(f"Failed to update: {e}")
 

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -21,6 +21,7 @@ class HKCAlarmCoordinator(DataUpdateCoordinator):
         self._last_update = None
         self._hkc_alarm = hkc_alarm
         self.panel_time = None
+        self._panel_time_delta = timedelta()
         self.status = None
         self.panel_data = None
         # self.sensor_data = None
@@ -33,13 +34,15 @@ class HKCAlarmCoordinator(DataUpdateCoordinator):
 
         def parse_panel_time():
             panel_time_str = self.panel_data.get("display", "")
+            now = datetime.now(timezone.utc)
             try:
-                now = datetime.now(timezone.utc)
                 self.panel_time = datetime.strptime(
                     panel_time_str, "%a %d %b %H:%M"
                 ).replace(year=now.year, tzinfo=timezone.utc)
+                self._panel_time_delta = self.panel_time - now
             except ValueError:
                 _logger.debug(f"Failed to parse panel time: {panel_time_str}")
+                self.panel_time = now + self._panel_time_delta
 
         try:
             now = datetime.now(timezone.utc)

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -38,7 +38,6 @@ class HKCAlarmCoordinator(DataUpdateCoordinator):
                 self.panel_time = datetime.strptime(
                     panel_time_str, "%a %d %b %H:%M"
                 ).replace(year=now.year, tzinfo=timezone.utc)
-                _logger.warning("panel_time=%s", self.panel_time)
             except ValueError:
                 _logger.debug(f"Failed to parse panel time: {panel_time_str}")
 

--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -1,15 +1,12 @@
+import logging
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
-from .const import DOMAIN
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
-
-import logging
-
-from homeassistant.core import callback
 
 
 _logger = logging.getLogger(__name__)

--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -5,6 +5,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from .const import DOMAIN
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from .const import DOMAIN
 
 import logging
 

--- a/custom_components/hkc_alarm/config_flow.py
+++ b/custom_components/hkc_alarm/config_flow.py
@@ -1,12 +1,10 @@
 """Config flow for HKC Alarm."""
+
 import logging
-from pyhkc.hkc_api import HKCAlarm
-from homeassistant import config_entries, exceptions
 import voluptuous as vol
-
+from pyhkc.hkc_api import HKCAlarm
+from homeassistant import config_entries
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
-
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/hkc_alarm/const.py
+++ b/custom_components/hkc_alarm/const.py
@@ -3,4 +3,5 @@
 # Integration domain identifier. This is the name used in the configuration.yaml file.
 DOMAIN = "hkc_alarm"
 DEFAULT_UPDATE_INTERVAL = 60  # Default update interval in seconds
+MIN_UPDATE_INTERVAL = 30  # Minimum update interval in seconds
 CONF_UPDATE_INTERVAL = "update_interval"

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -3,8 +3,8 @@ import pytz
 from homeassistant.core import callback
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from datetime import datetime, timedelta
 from .const import DOMAIN
+from datetime import datetime, timedelta
 
 _logger = logging.getLogger(__name__)
 

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -1,37 +1,39 @@
 import logging
-import asyncio
+from pyhkc.hkc_api import HKCAlarm
 import pytz
-from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from .const import DOMAIN
-from datetime import datetime, timedelta
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+from datetime import datetime, timezone, timedelta
+from homeassistant.util import Throttle
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 _logger = logging.getLogger(__name__)
 
 
-class HKCSensor(CoordinatorEntity):
-    _panel_data = {}  # Class variable shared among all instances
-    _update_lock = asyncio.Lock()  # Lock to ensure only one update at a time
-    _last_update = datetime.min  # Initialize with the earliest possible datetime
-    _panel_time_offset = None
+class HKCSensor(CoordinatorEntity, SensorEntity):
 
-    def __init__(self, hkc_alarm, input_data, coordinator):
-        super().__init__(coordinator)  # Ensure the coordinator is properly initialized
+    def __init__(self, hkc_alarm, input_data, alarm_coordinator, sensor_coordinator):
+        super().__init__(
+            sensor_coordinator
+        )  # Ensure the coordinator is properly initialized
         self._hkc_alarm = hkc_alarm
         self._input_data = input_data
-        self.coordinator = coordinator
+        self._alarm_coordinator = alarm_coordinator
+        self._sensor_coordinator = sensor_coordinator
 
     @property
     def extra_state_attributes(self):
         """Return the state attributes of the alarm sensors"""
-        if HKCSensor._panel_time_offset is None:
+        if self._alarm_coordinator.panel_time_offset is None:
             return None
 
-        attributes = {"Panel Offset": round(HKCSensor._panel_time_offset)}
+        attributes = {"Panel Offset": round(self._alarm_coordinator.panel_time_offset)}
         return attributes
 
     @property
@@ -61,7 +63,7 @@ class HKCSensor(CoordinatorEntity):
             return "Unused"
 
         # Parse panel time
-        panel_time_str = self._panel_data.get("display", "")
+        panel_time_str = self._alarm_coordinator.panel_data.get("display", "")
 
         try:
             panel_time = datetime.strptime(panel_time_str, "%a %d %b %H:%M")
@@ -70,7 +72,7 @@ class HKCSensor(CoordinatorEntity):
                 f"Failed to parse panel time: {panel_time_str} for sensor {self.name}. Falling back to previously known panel offset."
             )
             # Fallback to previously known panel offset
-            panel_time_offset = HKCSensor._panel_time_offset
+            panel_time_offset = self._alarm_coordinator.panel_time_offset
 
             if panel_time_offset is None:
                 # No previously known panel offset, we're stuck
@@ -119,7 +121,7 @@ class HKCSensor(CoordinatorEntity):
         # Calculate the difference in minutes
         minutes_difference = time_difference.total_seconds() / 60
 
-        HKCSensor._panel_time_offset = minutes_difference
+        self._alarm_coordinator.panel_time_offset = minutes_difference
 
         # Handle cases where the timestamp is very old or invalid
         if time_difference > timedelta(days=365):
@@ -157,11 +159,6 @@ class HKCSensor(CoordinatorEntity):
     def name(self):
         return self._input_data["description"]
 
-    @property
-    def should_poll(self):
-        """Return False, entities are updated by the coordinator."""
-        return False
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -169,7 +166,7 @@ class HKCSensor(CoordinatorEntity):
         matching_sensor_data = next(
             (
                 sensor_data
-                for sensor_data in self.coordinator.data
+                for sensor_data in self._sensor_coordinator.sensor_data
                 if sensor_data.get("inputId") == self._input_data.get("inputId")
             ),
             None,  # Default to None if no matching sensor data is found
@@ -185,59 +182,63 @@ class HKCSensor(CoordinatorEntity):
 
         self.async_write_ha_state()  # Update the state with the latest data
 
-    @classmethod
-    async def update_panel_data(cls, hkc_alarm, hass):
-        async with cls._update_lock:
-            now = datetime.utcnow()
-            if (now - cls._last_update) < timedelta(seconds=30):  # 30 seconds cooldown
-                return cls._panel_data  # Return existing data if updated recently
 
-            cls._panel_data = await hass.async_add_executor_job(hkc_alarm.get_panel)
-            cls._last_update = now  # Update the last update timestamp
-            return cls._panel_data  # Return the updated data
+class HKCSensorCoordinator(DataUpdateCoordinator):
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        hkc_alarm: HKCAlarm,
+        alarm_coordinator: DataUpdateCoordinator,
+        update_interval,
+    ) -> None:
+        super().__init__(
+            hass,
+            _logger,
+            config_entry=config_entry,
+            name="hkc_sensor_data",
+            update_interval=timedelta(seconds=update_interval),
+        )
+        self._last_update = datetime.min
+        self._hkc_alarm = hkc_alarm
+        self._alarm_coordinator = alarm_coordinator
+        self.sensor_data = None
 
-    async def async_update(self):
-        """Update the sensor."""
-        _logger.debug(f"Updating sensor {self.name}")
-        await self.coordinator.async_request_refresh()
+    async def _async_update_data(self):
+        @Throttle(timedelta(seconds=30))
+        def fetch_data():
+            _logger.warning("hkc_sensor_data fetch")
+            self.sensor_data = self._hkc_alarm.get_all_inputs()
 
-
-async def async_setup_entry(hass, entry, async_add_entities):
-    hkc_alarm = hass.data[DOMAIN][entry.entry_id]
-    update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-
-    async def _async_fetch_data():
         try:
-            hkc_alarm = hass.data[DOMAIN][entry.entry_id]["hkc_alarm"]
-            await HKCSensor.update_panel_data(hkc_alarm, hass)
-            hkc_alarm.panel_offset = HKCSensor._panel_time_offset
-            data = await hass.async_add_executor_job(hkc_alarm.get_all_inputs)
-            return data
+            await self._alarm_coordinator.async_refresh()
+            now = datetime.now(timezone.utc)
+            if now > self._last_update + timedelta(seconds=30):
+                self._last_update = now
+                await self.hass.async_add_executor_job(fetch_data)
+            return self.sensor_data
         except Exception as e:
             _logger.error(f"Exception occurred while fetching HKC data: {e}")
             raise UpdateFailed(f"Failed to update: {e}")
 
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _logger,
-        name="hkc_sensor_data",
-        update_method=_async_fetch_data,
-        update_interval=timedelta(seconds=update_interval),
-        always_update=True,
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    hkc_alarm = hass.data[DOMAIN][entry.entry_id]["hkc_alarm"]
+    update_interval = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+    alarm_coordinator = hass.data[DOMAIN][entry.entry_id]["alarm_coordinator"]
+    sensor_coordinator = HKCSensorCoordinator(
+        hass, entry, hkc_alarm, alarm_coordinator, update_interval
     )
+    await sensor_coordinator.async_config_entry_first_refresh()
 
-    await coordinator.async_config_entry_first_refresh()
-
-    all_inputs = coordinator.data
+    all_inputs = sensor_coordinator.data
     # Filter out the inputs with empty description
     filtered_inputs = [
         input_data for input_data in all_inputs if input_data["description"]
     ]
     async_add_entities(
         [
-            HKCSensor(
-                hass.data[DOMAIN][entry.entry_id]["hkc_alarm"], input_data, coordinator
-            )
+            HKCSensor(hkc_alarm, input_data, alarm_coordinator, sensor_coordinator)
             for input_data in filtered_inputs
         ],
         True,

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -1,10 +1,10 @@
+from datetime import datetime, timedelta
 import logging
 import pytz
-from homeassistant.core import callback
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
-from datetime import datetime, timedelta
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add `DataUpdateCoordinator` subclass that polls the system and panel status, and a separate subclass that polls the sensors. These are created in `__init__.py` so that the update interval can be updated more easily by the options flow, avoid `UpdateFailed` exceptions being raised in platform `async_setup_entry` which triggers a warning, and so that the sensor platform can access the panel status without fetching its own a copy.

The panel display time parsing has also been moved to the coordinator.

The time difference calculation has also been fixed, previously this was redefined to always be `current_time - panel_time` rather than the difference between panel time and the sensor update time.

Still to do:
* Move sensor state calculation to `_handle_coordinator_update` once PR #37 has been resolved