### PR TITLE
Add options flow to integration

### DIFF
--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -118,7 +118,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         alarm_coordinator.update_interval = timedelta(seconds=update_interval)
         sensor_coordinator.update_interval = timedelta(seconds=update_interval)
 
-    entry.add_update_listener(update_options)
+    entry.async_on_unload(entry.add_update_listener(update_options))
 
     await hass.config_entries.async_forward_entry_setups(
         entry, ["alarm_control_panel", "sensor"]

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -97,7 +97,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry):
     new_options = {**entry.options}
     if entry.version < 3:
         # Move update_interval to options so it can be changed on the fly
-        new_options[CONF_UPDATE_INTERVAL] = DEFAULT_UPDATE_INTERVAL
+        if CONF_UPDATE_INTERVAL not in new_options:
+            new_options[CONF_UPDATE_INTERVAL] = DEFAULT_UPDATE_INTERVAL
         if (update_interval := new_data.get(CONF_UPDATE_INTERVAL)) is not None:
             new_options[CONF_UPDATE_INTERVAL] = update_interval
             del new_data[CONF_UPDATE_INTERVAL]

--- a/custom_components/hkc_alarm/__init__.py
+++ b/custom_components/hkc_alarm/__init__.py
@@ -141,11 +141,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     @callback
-    def update_options(updated_entry: ConfigEntry) -> None:
-        update_interval = updated_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-        hass.data[DOMAIN][updated_entry.entry_id]["update_interval"] = update_interval
+    async def update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+        update_interval = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        hass.data[DOMAIN][entry.entry_id]["update_interval"] = update_interval
         alarm_coordinator.update_interval = timedelta(seconds=update_interval)
         sensor_coordinator.update_interval = timedelta(seconds=update_interval)
+        await sensor_coordinator.async_refresh()  # will refresh alarm_coordinator
 
     entry.async_on_unload(entry.add_update_listener(update_options))
 

--- a/custom_components/hkc_alarm/config_flow.py
+++ b/custom_components/hkc_alarm/config_flow.py
@@ -12,7 +12,9 @@ _LOGGER = logging.getLogger(__name__)
 class HKCAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for HKC Alarm."""
 
-    VERSION = 2
+    VERSION = 3
+    MINOR_VERSION = 0
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/custom_components/hkc_alarm/config_flow.py
+++ b/custom_components/hkc_alarm/config_flow.py
@@ -1,13 +1,10 @@
 """Config flow for HKC Alarm."""
 import logging
-from pyhkc.hkc_api import HKCAlarm
-from homeassistant import config_entries, exceptions
-from homeassistant.core import callback
 import voluptuous as vol
-
+from pyhkc.hkc_api import HKCAlarm
+from homeassistant import config_entries
+from homeassistant.core import callback
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL
-
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/hkc_alarm/translations/en.json
+++ b/custom_components/hkc_alarm/translations/en.json
@@ -9,12 +9,6 @@
           "panel_id": "Panel ID",
           "update_interval": "Update Interval (seconds)"
         }
-      },
-      "options": {
-        "title": "Options",
-        "data": {
-          "update_interval": "Update Interval (seconds)"
-        }
       }
     },
     "error": {
@@ -24,6 +18,16 @@
     },
     "abort": {
       "already_configured": "HKC Alarm integration is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options",
+        "data": {
+          "update_interval": "Update Interval (seconds)"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Replacement PR for #39 

Enable reconfiguration of the update interval via options flow. This allows the update interval to be changed on the fly, without restarting the integration.

## Breaking Change
`update_interval` is moved from `config_entry.data` to `config_entry.options`. The current value is migrated on the first integration start after upgrading.

## All Changes
* Add options flow
* Move CONF_UPDATE_INTERVAL from config entry data to options
* Bump config entry version to 3.0
* Add `async_migrate_entry` to migrate to new config entry version
* Unload update listener on integration unload
* Refresh coordinators to use updated `update_interval`
* Don't overwrite CONF_UPDATE_INTERVAL in options if it already exists