### PR TITLE
Use new entity naming scheme

### DIFF
--- a/custom_components/hkc_alarm/alarm_control_panel.py
+++ b/custom_components/hkc_alarm/alarm_control_panel.py
@@ -30,6 +30,9 @@ class HKCAlarmControlPanel(CoordinatorEntity, AlarmControlPanelEntity):
         self._state = None
         self._alarm_coordinator = alarm_coordinator
 
+        self._attr_has_entity_name = True
+        self._attr_name = None
+
     @property
     def unique_id(self):
         """Return the unique ID of the sensor."""
@@ -62,10 +65,6 @@ class HKCAlarmControlPanel(CoordinatorEntity, AlarmControlPanelEntity):
             "model": "HKC Alarm",
             "sw_version": "1.0.0",
         }
-
-    @property
-    def name(self):
-        return "HKC Alarm System"
 
     @property
     def available(self) -> bool:

--- a/custom_components/hkc_alarm/sensor.py
+++ b/custom_components/hkc_alarm/sensor.py
@@ -20,6 +20,9 @@ class HKCSensor(CoordinatorEntity, SensorEntity):
         self._alarm_coordinator = alarm_coordinator
         self._sensor_coordinator = sensor_coordinator
 
+        self._attr_has_entity_name = True
+        self._attr_name = input_data["description"]
+
     @property
     def unique_id(self):
         """Return the unique ID of the sensor."""
@@ -34,10 +37,6 @@ class HKCSensor(CoordinatorEntity, SensorEntity):
             "model": "HKC Alarm",
             "sw_version": "1.0.0",
         }
-
-    @property
-    def name(self):
-        return self._input_data["description"]
 
     def _get_sensor_state(self) -> str:
         """Determine the state of the sensor."""

--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -58,7 +58,7 @@ async def test_name():
     alarm_control_panel = HKCAlarmControlPanel(
         get_mock_hkc_alarm(), {}, get_mock_alarm_coordinator()
     )
-    assert alarm_control_panel.name == "HKC Alarm System"
+    assert alarm_control_panel.name == None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -116,7 +116,7 @@ async def test_name():
         get_mock_alarm_coordinator(),
         get_mock_sensor_coordinator(),
     )
-    assert sensor.name == "Front Door"  # Assuming description is 'Front Door'
+    assert sensor.name == "HKC Alarm System Front Door"  # Assuming description is 'Front Door'
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -116,7 +116,7 @@ async def test_name():
         get_mock_alarm_coordinator(),
         get_mock_sensor_coordinator(),
     )
-    assert sensor.name == "HKC Alarm System Front Door"  # Assuming description is 'Front Door'
+    assert sensor.name == "Front Door"  # Assuming description is 'Front Door'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use the new naming scheme for entities as described in the [Entity docs](https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations).

After upgrading the integration to a version containing this PR, entity IDs for existing integration instances will not be changed, as the `unique_id` value for the `alarm_control_panel` and `sensor` entities have not changed. The friendly names for the entities will however now be prepended with the device name, unless they were previously customised by the user.

For new instances of the integration added after upgrading, the entity IDs will be generated using the full entity name, and the device name will be prepended to the entity name as a result.